### PR TITLE
fix(FrontendWorkflow/ListboxField): Fix bug where readonly ListboxField (LookupField) threw validation errors when the field was left empty.

### DIFF
--- a/code/controllers/ObjectCreatorPage_FrontEndWorkflowController.php
+++ b/code/controllers/ObjectCreatorPage_FrontEndWorkflowController.php
@@ -184,6 +184,8 @@ class ObjectCreatorPage_FrontEndWorkflowController extends FrontEndWorkflowContr
 				// NOTE(Jake): Add '_Readonly' as the name allows for ListboxField to show its data properly in readonly mode.
 				// NOTE(Jake): Used to add '_Readonly' to every field but that caused 'FrontendWorkflowForm' to not validate.
 				$field->setName($field->getName().'_Readonly');
+				// NOTE(Jake): Fixes issue where LookupField validates false when blank. (not ideal for ListboxField)
+				$field->setHasEmptyDefault(true);
 			}
 			$field = $field->performReadonlyTransformation();
 			$fields->insertBefore($field, $firstFieldName);


### PR DESCRIPTION
fix(FrontendWorkflow/ListboxField): Fix bug where readonly ListboxField (LookupField) threw validation errors when the field was left empty.
