### PR TITLE
fix(ObjectCreatorPage): Fix regression in d4a276a0fb325f3ca2787e959d1d3940499dcb8a.

### DIFF
--- a/code/controllers/ObjectCreatorPage_FrontEndWorkflowController.php
+++ b/code/controllers/ObjectCreatorPage_FrontEndWorkflowController.php
@@ -76,14 +76,10 @@ class ObjectCreatorPage_FrontEndWorkflowController extends FrontEndWorkflowContr
 		{
 			// Get Context Object and detect whether we can review/edit with workflows or not
 			$contextObj = $this->getContextObjectWithIDAndClass($id, $this->parentController->CreateType);
-			if ($contextObj)
+			if ($contextObj && $contextObj->canEdit())
 			{
-				$workflow = $contextObj->getWorkflowInstance();
-				if ($workflow && $workflow->CurrentAction()->canEditTarget($contextObj))
-				{
-					$actions = $form->Actions();
-					$actions->unshift(FormAction::create('doReview', 'Go to Review'));
-				}
+				$actions = $form->Actions();
+				$actions->unshift(FormAction::create('doReview', 'Go to Review'));
 			}
 		}
 	}
@@ -105,8 +101,7 @@ class ObjectCreatorPage_FrontEndWorkflowController extends FrontEndWorkflowContr
 		{
 			return;
 		}
-		$workflow = $contextObj->getWorkflowInstance();
-		if (!$workflow->CurrentAction()->canEditTarget($contextObj))
+		if (!$contextObj->canEdit())
 		{
 			return;
 		}
@@ -138,7 +133,7 @@ class ObjectCreatorPage_FrontEndWorkflowController extends FrontEndWorkflowContr
 			user_error('No workflow instance on page.', E_USER_WARNING);
 			return '';
 		}
-		if (!$workflow->CurrentAction()->canEditTarget($contextObj))
+		if (!$contextObj->canEdit())
 		{
 			user_error('Current user does not have edit permissions to review this page.', E_USER_WARNING);
 			return '';

--- a/code/pages/ObjectCreatorPage.php
+++ b/code/pages/ObjectCreatorPage.php
@@ -308,11 +308,6 @@ class ObjectCreatorPage extends Page {
 			return false;
 		}
 
-		if ($record && !$record->WorkflowDefinition()) {
-			// Cannot review if the record no longer has a workflow applied.
-			return false;
-		}
-
 		if (!$member) {
 			// Cannot review if not a logged in member.
 			return false;


### PR DESCRIPTION
fix(ObjectCreatorPage): Fix regression in d4a276a0fb325f3ca2787e959d1d3940499dcb8a, changes from WorkflowActionInstance::canEditTarget() to DataObject::canEdit(), which will then go through WorkflowApplicable::canEdit() and do all the permission checks properly.

Needs further testing in the context it was changed for, but seems to be all good so far.