### PR TITLE
fix(ObjectCreatorPage): New data objects created with defaults

### DIFF
--- a/code/pages/ObjectCreatorPage.php
+++ b/code/pages/ObjectCreatorPage.php
@@ -507,7 +507,7 @@ class ObjectCreatorPage_Controller extends Page_Controller {
 		{
 			if (!$this->editObject) {
 				$class = $this->CreateType;
-				$this->editObject = $class::create();
+				$this->editObject = $class::create(null, false);
 				unset($class);
 			}
 			if ($this->editObject instanceof FrontendCreatable || $this->editObject->hasMethod('getFrontendCreateFields')) {


### PR DESCRIPTION
Solves: https://github.com/nyeholt/silverstripe-frontend-objects/issues/20

A querk with the way SilverStripe instantiates objects means that this line will return a singleton without it's defaults initialised. This change mimics default constructor args but with the singleton flag set to false.